### PR TITLE
Add directory or bundle loading support

### DIFF
--- a/src/Context/AliceContextInterface.php
+++ b/src/Context/AliceContextInterface.php
@@ -47,7 +47,9 @@ interface AliceContextInterface
     public function thereAreFixtures($fixturesFile, $persister = null);
 
     /**
+     * @Given the following fixtures are loaded:
      * @Given the following fixtures files are loaded:
+     * @Given the following fixtures are loaded with the persister :persister:
      * @Given the following fixtures files are loaded with the persister :persister:
      *
      * @param TableNode          $fixturesFiles Path to the fixtures

--- a/tests/Features/ODM/loader.feature
+++ b/tests/Features/ODM/loader.feature
@@ -12,6 +12,11 @@ Feature: Test Doctrine ODM context
     Given the fixtures file "@TestBundle/DataFixtures/ODM/dummy.yml" is loaded
     Then the database should contain 10 "dummy" entities
 
+  Scenario: Loads a fixtures directory with @Bundlename notation
+    Given the database is empty
+    Given the fixtures "@TestBundle" are loaded
+    Then the database should contain 11 "dummy" entities
+
   Scenario: Loads a fixture file based on basePath
     Given the database is empty
     Given the fixtures file "another_dummy.yml" is loaded
@@ -21,6 +26,11 @@ Feature: Test Doctrine ODM context
     Given the database is empty
     Given the fixtures file "/home/travis/build/theofidry/AliceBundleExtension/tests/Features/fixtures/ODM/another_dummy.yml" is loaded
     Then the database should contain 10 "another_dummy" entities
+
+  Scenario: Loads a fixture directory with absolute path
+    Given the database is empty
+    Given the fixtures "/home/travis/build/theofidry/AliceBundleExtension/tests/Features/fixtures/ODM/" are loaded
+    Then the database should contain 11 "another_dummy" entities
 
   Scenario: Loads a fixture file with a custom persister
     Given the database is empty
@@ -39,4 +49,11 @@ Feature: Test Doctrine ODM context
     Given the following fixtures files are loaded:
       | @TestBundle/DataFixtures/ODM/dummy.yml             |
       | @TestBundle/DataFixtures/ODM/one_another_dummy.yml |
+    Then the database should contain 11 "dummy" entities
+
+  Scenario: Loads several duplicated fixtures
+    Given the database is empty
+    Given the following fixtures files are loaded:
+      | @TestBundle/DataFixtures/ODM/dummy.yml |
+      | @TestBundle                            |
     Then the database should contain 11 "dummy" entities

--- a/tests/Features/ORM/loader.feature
+++ b/tests/Features/ORM/loader.feature
@@ -12,6 +12,11 @@ Feature: Test Doctrine ORM context
     Given the fixtures file "@TestBundle/DataFixtures/ORM/dummy.yml" is loaded
     Then the database should contain 10 "dummy" entities
 
+  Scenario: Loads a fixtures directory with @Bundlename notation
+    Given the database is empty
+    Given the fixtures "@TestBundle" are loaded
+    Then the database should contain 11 "dummy" entities
+
   Scenario: Loads a fixture file based on basePath
     Given the database is empty
     Given the fixtures file "another_dummy.yml" is loaded
@@ -21,6 +26,11 @@ Feature: Test Doctrine ORM context
     Given the database is empty
     Given the fixtures file "/home/travis/build/theofidry/AliceBundleExtension/tests/Features/fixtures/ORM/another_dummy.yml" is loaded
     Then the database should contain 10 "another_dummy" entities
+
+  Scenario: Loads a fixture directory with absolute path
+    Given the database is empty
+    Given the fixtures "/home/travis/build/theofidry/AliceBundleExtension/tests/Features/fixtures/ORM" are loaded
+    Then the database should contain 11 "another_dummy" entities
 
   Scenario: Loads a fixture file with a custom persister
     Given the database is empty
@@ -39,4 +49,11 @@ Feature: Test Doctrine ORM context
     Given the following fixtures files are loaded:
       | @TestBundle/DataFixtures/ORM/dummy.yml             |
       | @TestBundle/DataFixtures/ORM/one_another_dummy.yml |
+    Then the database should contain 11 "dummy" entities
+
+  Scenario: Loads several duplicated fixtures
+    Given the database is empty
+    Given the following fixtures files are loaded:
+      | @TestBundle/DataFixtures/ORM/dummy.yml |
+      | @TestBundle                            |
     Then the database should contain 11 "dummy" entities


### PR DESCRIPTION
Hey!

Currently, this extension only allows to load file by file and don't provide a way to load a directory or a bundle. It would not be a problem if I don't rely on a data loader but I do and so, I can't really rely on this extension.

Then, this PR tries to add support for a directory or a bundle without breaking the BC. For bundle, I don't pass an env otherwise I would need to break the BC.

You can load a directory or a bundle with for example:

```
Given the following fixtures are loaded:
    | @AcmeDemoBundle    |
    | /path/to/directory |
```

What do you think?
