### PR TITLE
Fix fixtures loaded by environment

### DIFF
--- a/src/Context/Doctrine/AbstractAliceContext.php
+++ b/src/Context/Doctrine/AbstractAliceContext.php
@@ -202,7 +202,7 @@ abstract class AbstractAliceContext implements KernelAwareContext, AliceContextI
         if (false === empty($fixtureBundles)) {
             $fixturesFiles = array_merge(
                 $fixturesFiles,
-                $this->fixturesFinder->getFixtures($this->kernel, $fixtureBundles, null)
+                $this->fixturesFinder->getFixtures($this->kernel, $fixtureBundles, $this->kernel->getEnvironment())
             );
         }
 


### PR DESCRIPTION
Hey!

Since I integrate directory/bundle fixtures support in my previous PR (#15), this one does not deal with the environment. This PR fixes it by relying on the kernel env.
