### PR TITLE
Update deprecated dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/orm": "~2.4",
         "doctrine/doctrine-bundle": "~1.2",
         "doctrine/doctrine-fixtures-bundle": "~2.2",
-        "friendsofphp/php-cs-fixer": "~1.0",
+        "friendsofphp/php-cs-fixer": "~2.0@dev",
         "phpunit/phpunit": "^4.8",
         "symfony/console": "~2.1",
         "symfony/expression-language": "^2.7",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/orm": "~2.4",
         "doctrine/doctrine-bundle": "~1.2",
         "doctrine/doctrine-fixtures-bundle": "~2.2",
-        "fabpot/php-cs-fixer": "~2.0@dev",
+        "friendsofphp/php-cs-fixer": "~1.0",
         "phpunit/phpunit": "^4.8",
         "symfony/console": "~2.1",
         "symfony/expression-language": "^2.7",


### PR DESCRIPTION
The `fabpot/php-cs-fixer` library has been deprecated and should be replaced by the `friendsofphp/php-cs-fixer` library.
At the moment, the only problem encountered while keeping the library is a warning display in the console during composer usage. It might change in the future though.

See #18
